### PR TITLE
Explicitly disallow multi() descriptor  and raise an exception if used

### DIFF
--- a/bitcoin_usb/address_types.py
+++ b/bitcoin_usb/address_types.py
@@ -315,7 +315,17 @@ class SimplePubKeyProvider:
 
 
 def _get_descriptor_instances(descriptor: Descriptor) -> List[Descriptor]:
-    "Returns the linear chain of chained descriptors . Multiple subdescriptors return an error"
+    """
+    Returns the linear chain of chained descriptors, and converts MultisigDescriptor into SortedMultisigDescriptor if possible.
+    Multiple subdescriptors return an error
+
+
+    Args:
+        descriptor (Descriptor): _description_
+
+    Returns:
+        List[Descriptor]: _description_
+    """
     assert len(descriptor.subdescriptors) <= 1
     if descriptor.subdescriptors:
         result = [

--- a/bitcoin_usb/address_types.py
+++ b/bitcoin_usb/address_types.py
@@ -22,6 +22,21 @@ from hwilib.descriptor import (
 from hwilib.key import KeyOriginInfo
 
 
+class SortedMultisigDescriptor(MultisigDescriptor):
+    def __init__(self, pubkeys: List[PubkeyProvider], thresh: int) -> None:
+        super().__init__(pubkeys, thresh, True)
+
+    @classmethod
+    def is_sorted_multisig(cls, descriptor: Descriptor) -> bool:
+        return isinstance(descriptor, MultisigDescriptor) and descriptor.is_sorted
+
+    @classmethod
+    def from_multisig_descriptor(cls, descriptor: Descriptor):
+        assert isinstance(descriptor, MultisigDescriptor)
+        assert descriptor.is_sorted
+        return cls(descriptor.pubkeys, descriptor.thresh)
+
+
 class ConstDerivationPaths:
     receive = "/0/*"
     change = "/1/*"
@@ -136,7 +151,7 @@ class AddressTypes:
         bdk_descriptor_secret=None,
         info_url="https://github.com/bitcoin/bips/blob/master/bip-0048.mediawiki",
         description="Nested (multi sig) addresses that look like 3addresses",
-        hwi_descriptor_classes=(SHDescriptor, WSHDescriptor, MultisigDescriptor),
+        hwi_descriptor_classes=(SHDescriptor, WSHDescriptor, SortedMultisigDescriptor),
     )
     p2wsh = AddressType(
         "p2wsh",
@@ -146,7 +161,7 @@ class AddressTypes:
         bdk_descriptor_secret=None,
         info_url="https://github.com/bitcoin/bips/blob/master/bip-0048.mediawiki",
         description="SegWit (multi sig) addresses that look like bc1addresses",
-        hwi_descriptor_classes=(WSHDescriptor, MultisigDescriptor),
+        hwi_descriptor_classes=(WSHDescriptor, SortedMultisigDescriptor),
     )
 
 
@@ -303,12 +318,20 @@ def _get_descriptor_instances(descriptor: Descriptor) -> List[Descriptor]:
     "Returns the linear chain of chained descriptors . Multiple subdescriptors return an error"
     assert len(descriptor.subdescriptors) <= 1
     if descriptor.subdescriptors:
-        result = [descriptor]
+        result = [
+            SortedMultisigDescriptor.from_multisig_descriptor(descriptor)
+            if SortedMultisigDescriptor.is_sorted_multisig(descriptor)
+            else descriptor
+        ]
         for subdescriptor in descriptor.subdescriptors:
             result += _get_descriptor_instances(subdescriptor)
         return result
     else:
-        return [descriptor]
+        return [
+            SortedMultisigDescriptor.from_multisig_descriptor(descriptor)
+            if SortedMultisigDescriptor.is_sorted_multisig(descriptor)
+            else descriptor
+        ]
 
 
 def _find_matching_address_type(
@@ -348,11 +371,13 @@ class DescriptorInfo:
                 )
 
         if self.address_type.is_multisig:
-            assert self.address_type.hwi_descriptor_classes[-1] == MultisigDescriptor
-            hwi_descriptor = MultisigDescriptor(
+            assert (
+                self.address_type.hwi_descriptor_classes[-1] != MultisigDescriptor
+            )  # multi() is not suuported, and may not be added in AddressType
+            assert self.address_type.hwi_descriptor_classes[-1] == SortedMultisigDescriptor
+            hwi_descriptor = SortedMultisigDescriptor(
                 pubkeys=[provider.to_hwi_pubkey_provider() for provider in self.spk_providers],
                 thresh=self.threshold,
-                is_sorted=True,
             )
         else:
             hwi_descriptor = self.address_type.hwi_descriptor_classes[-1](
@@ -369,12 +394,24 @@ class DescriptorInfo:
 
     @classmethod
     def from_str(cls, descriptor_str: str) -> "DescriptorInfo":
+        """
+        Requres the descriptor_str to be a nested chain of descriptors, that have at most 1 branch
+        If there are more than 1 subdescriptors (branches), it will raise an Exception
+
+        Args:
+            descriptor_str (str): _description_
+
+        Raises:
+            ValueError: _description_
+
+        Returns:
+            DescriptorInfo: _description_
+        """
         hwi_descriptor = parse_descriptor(descriptor_str)
+        linear_chain_descriptors = _get_descriptor_instances(hwi_descriptor)
 
         # first we need to identify the address type
-        address_type = _find_matching_address_type(
-            _get_descriptor_instances(hwi_descriptor), get_all_address_types()
-        )
+        address_type = _find_matching_address_type(linear_chain_descriptors, get_all_address_types())
         if not address_type:
             supported_types = [address_type.short_name for address_type in get_all_address_types()]
             raise ValueError(
@@ -383,16 +420,12 @@ class DescriptorInfo:
 
         # get the     pubkey_providers, by "walking to the end of desciptors"
         threshold = 1
-        subdescriptor = hwi_descriptor
-        for descritptor_class in address_type.hwi_descriptor_classes:
-            # just double checking that _find_matching_address_type did its job correctly
-            assert isinstance(subdescriptor, descritptor_class)
-            subdescriptor = subdescriptor.subdescriptors[0] if subdescriptor.subdescriptors else subdescriptor
+        last_descriptor = linear_chain_descriptors[-1]
 
-        pubkey_providers = subdescriptor.pubkeys
-        if isinstance(subdescriptor, MultisigDescriptor):
+        pubkey_providers = last_descriptor.pubkeys
+        if isinstance(last_descriptor, MultisigDescriptor):
             # last descriptor is a multisig
-            threshold = subdescriptor.thresh
+            threshold = last_descriptor.thresh
 
         return DescriptorInfo(
             address_type=address_type,

--- a/bitcoin_usb/device.py
+++ b/bitcoin_usb/device.py
@@ -6,7 +6,6 @@ from typing import Callable
 
 import hwilib.commands as hwi_commands
 from hwilib.common import Chain
-from hwilib.descriptor import MultisigDescriptor as HWIMultisigDescriptor
 from hwilib.devices.bitbox02 import Bitbox02Client, CLINoiseConfig
 from hwilib.devices.bitbox02_lib import bitbox02
 from hwilib.devices.bitbox02_lib.communication import devices as bitbox02devices
@@ -35,6 +34,7 @@ import bdkpython as bdk
 from .address_types import (
     AddressType,
     DescriptorInfo,
+    SortedMultisigDescriptor,
     get_all_address_types,
     get_hwi_address_type,
 )
@@ -402,10 +402,9 @@ class USBDevice(BaseDevice, QObject):
             ]
             return self.client.display_multisig_address(
                 get_hwi_address_type(desc_infos.address_type),
-                HWIMultisigDescriptor(
+                SortedMultisigDescriptor(
                     pubkeys=pubkey_providers,
                     thresh=desc_infos.threshold,
-                    is_sorted=True,
                 ),
             )
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ disable_error_code = "assignment"
 
 [tool.poetry]
 name = "bitcoin-usb"
-version = "0.7.8"
+version = "0.7.9"
 authors = ["andreasgriffin <andreasgriffin@proton.me>"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/tests/test_descriptor_info.py
+++ b/tests/test_descriptor_info.py
@@ -148,6 +148,22 @@ def test_wsh_multisig():
     }
 
 
+def test_unsupported_unsorted_multisig():
+    s = "wsh(multi(2,[45f35351/48h/1h/0h/2h]tpubDEY3tNWvDs8J6xAmwoirxgff61gPN1V6U5numeb6xjvZRB883NPPpRYHt2A6fUE3YyzDLezFfuosBdXsdXJhJUcpqYWF9EEBmWqG3rG8sdy/<0;1>/*,[829074ff/48h/1h/0h/2h]tpubDDx9arPwEvHGnnkKN1YJXFE4W6JZXyVX9HGjZW75nWe1FCsTYu2k3i7VtCwhGR9zj6UUYnseZUnwL7T6Znru3NmXkcjEQxMqRx7Rxz8rPp4/<0;1>/*,[d5b43540/48h/1h/0h/2h]tpubDFnCcKU3iUF4sPeQC68r2ewDaBB7TvLmQBTs12hnNS8nu6CPjZPmzapp7Woz6bkFuLfSjSpg6gacheKBaWBhDnEbEpKtCnVFdQnfhYGkPQF/<0;1>/*))"
+
+    with pytest.raises(ValueError) as exc_info:
+        DescriptorInfo.from_str(s)
+
+    # Extract the exception message
+    exception_message = str(exc_info.value)
+
+    # Compare the exception message
+    assert (
+        exception_message
+        == "descriptor wsh(multi(2,[45f35351/48h/1h/0h/2h]tpubDEY3tNWvDs8J6xAmwoirxgff61gPN1V6U5numeb6xjvZRB883NPPpRYHt2A6fUE3YyzDLezFfuosBdXsdXJhJUcpqYWF9EEBmWqG3rG8sdy/<0;1>/*,[829074ff/48h/1h/0h/2h]tpubDDx9arPwEvHGnnkKN1YJXFE4W6JZXyVX9HGjZW75nWe1FCsTYu2k3i7VtCwhGR9zj6UUYnseZUnwL7T6Znru3NmXkcjEQxMqRx7Rxz8rPp4/<0;1>/*,[d5b43540/48h/1h/0h/2h]tpubDFnCcKU3iUF4sPeQC68r2ewDaBB7TvLmQBTs12hnNS8nu6CPjZPmzapp7Woz6bkFuLfSjSpg6gacheKBaWBhDnEbEpKtCnVFdQnfhYGkPQF/<0;1>/*)) cannot be matched to a supported template. Supported templates are ['p2pkh', 'p2sh-p2wpkh', 'p2wpkh', 'p2tr', 'p2sh-p2wsh', 'p2wsh']"
+    )
+
+
 def test_unsupported_sh():
     s = "sh(sortedmulti(2,[45f35351/48h/1h/0h/2h]tpubDEY3tNWvDs8J6xAmwoirxgff61gPN1V6U5numeb6xjvZRB883NPPpRYHt2A6fUE3YyzDLezFfuosBdXsdXJhJUcpqYWF9EEBmWqG3rG8sdy/<0;1>/*,[829074ff/48h/1h/0h/2h]tpubDDx9arPwEvHGnnkKN1YJXFE4W6JZXyVX9HGjZW75nWe1FCsTYu2k3i7VtCwhGR9zj6UUYnseZUnwL7T6Znru3NmXkcjEQxMqRx7Rxz8rPp4/<0;1>/*,[d5b43540/48h/1h/0h/2h]tpubDFnCcKU3iUF4sPeQC68r2ewDaBB7TvLmQBTs12hnNS8nu6CPjZPmzapp7Woz6bkFuLfSjSpg6gacheKBaWBhDnEbEpKtCnVFdQnfhYGkPQF/<0;1>/*))"
 


### PR DESCRIPTION
Bug discovered in  https://github.com/andreasgriffin/bitcoin-safe/issues/79