### PR TITLE
Fix threading issues in Trezor 7 and BitBox02 device dialogs

### DIFF
--- a/bitcoin_usb/device.py
+++ b/bitcoin_usb/device.py
@@ -2,6 +2,7 @@ import logging
 import threading
 from abc import abstractmethod
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -16,7 +17,18 @@ from hwilib.devices.jadepy.jade import DEFAULT_BLE_DEVICE_NAME
 from hwilib.devices.trezor import TrezorClient
 from hwilib.hwwclient import HardwareWalletClient
 from hwilib.psbt import PSBT
-from PyQt6.QtCore import QCoreApplication, QEventLoop, QObject, Qt, QThread, pyqtSignal
+from PyQt6 import sip
+from PyQt6.QtCore import (
+    Q_ARG,
+    QCoreApplication,
+    QEventLoop,
+    QMetaObject,
+    QObject,
+    Qt,
+    QThread,
+    pyqtSignal,
+    pyqtSlot,
+)
 from PyQt6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
@@ -26,7 +38,6 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from bitcoin_usb.dialogs import Worker
 from bitcoin_usb.i18n import translate
 from bitcoin_usb.jade_ble_client import JadeBleClient
 from bitcoin_usb.trezor_thp import TrezorThpClient, is_trezor_modern_device
@@ -41,6 +52,57 @@ from .address_types import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _PairingRequest:
+    code: str
+    device_response: Callable[[], bool]
+    done: threading.Event = field(default_factory=threading.Event)
+    result: bool | None = None
+    error: BaseException | None = None
+
+
+class _ThreadedDialogBridge(QObject):
+    finished = pyqtSignal(object)
+    error = pyqtSignal(object)
+
+
+class _MainThreadBitBox02PairingPrompt(QObject):
+    @pyqtSlot(object)
+    def show_pairing_dialog(self, payload: object) -> None:
+        if not isinstance(payload, _PairingRequest):
+            raise TypeError(f"Unexpected payload type: {type(payload)!r}")
+
+        try:
+            dialog = ThreadedCapturePrintDialogBitBox02(
+                func=payload.device_response,
+                title=translate("usb", "Pair Bitbox02"),
+            )
+            dialog.add_text(
+                translate(
+                    "usb",
+                    "Please compare and confirm the pairing code on your BitBox02:\n\n{code}",
+                ).format(code=payload.code)
+            )
+            payload.result = dialog.get_result()
+        except BaseException as exc:
+            payload.error = exc
+        finally:
+            payload.done.set()
+
+
+_MAIN_THREAD_BITBOX02_PAIRING_PROMPT: _MainThreadBitBox02PairingPrompt | None = None
+
+
+def _get_main_thread_bitbox02_pairing_prompt() -> _MainThreadBitBox02PairingPrompt:
+    global _MAIN_THREAD_BITBOX02_PAIRING_PROMPT
+    if _MAIN_THREAD_BITBOX02_PAIRING_PROMPT is None or sip.isdeleted(_MAIN_THREAD_BITBOX02_PAIRING_PROMPT):
+        _MAIN_THREAD_BITBOX02_PAIRING_PROMPT = _MainThreadBitBox02PairingPrompt()
+        app = QCoreApplication.instance()
+        if app is not None:
+            _MAIN_THREAD_BITBOX02_PAIRING_PROMPT.moveToThread(app.thread())
+    return _MAIN_THREAD_BITBOX02_PAIRING_PROMPT
 
 
 def create_custom_message_box(
@@ -100,12 +162,15 @@ class ThreadedCapturePrintDialogBitBox02(QDialog):
         self.label = QLabel(message)
         self._layout.addWidget(self.label)
 
-        # Setup worker and thread
-        self.worker = Worker(func, *args, **kwargs)
-        self._thread = QThread()
-        self.worker.moveToThread(self._thread)
-        self.worker.finished.connect(self.handle_func_result)
-        self._thread.started.connect(self.worker.run)
+        self._func = func
+        self._args = args
+        self._kwargs = kwargs
+        self._thread: threading.Thread | None = None
+        self._worker_error: BaseException | None = None
+        self.func_result = False
+        self._bridge = _ThreadedDialogBridge(self)
+        self._bridge.finished.connect(self.handle_func_result)
+        self._bridge.error.connect(self.handle_func_error)
 
         self.loop = QEventLoop()  # Event loop to block for synchronous execution
 
@@ -121,21 +186,40 @@ class ThreadedCapturePrintDialogBitBox02(QDialog):
         self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
 
-    def handle_func_result(self, result):
+    def handle_func_result(self, result: object) -> None:
         self.func_result = result
         if self.loop.isRunning():
             self.loop.exit()  # Exit the loop only if it's running
 
-    def add_text(self, s: str):
+    def handle_func_error(self, error: object) -> None:
+        if isinstance(error, BaseException):
+            self._worker_error = error
+        else:
+            self._worker_error = RuntimeError(str(error))
+        if self.loop.isRunning():
+            self.loop.exit()
+        if self.dialog_loop.isRunning():
+            self.dialog_loop.exit(0)
+        self.close()
+
+    def _run_func(self) -> None:
+        try:
+            result = self._func(*self._args, **self._kwargs)
+        except BaseException as exc:
+            self._bridge.error.emit(exc)
+            return
+        self._bridge.finished.emit(result)
+
+    def add_text(self, s: str) -> None:
         old_text = self.label.text()
         self.label.setText(old_text + "\n\n" + s)
 
-    def accept(self):
+    def accept(self) -> None:
         self.button_click_result = True
         self.dialog_loop.exit(0)  # Stop the event loop
         super().accept()
 
-    def reject(self):
+    def reject(self) -> None:
         self.button_click_result = False
         self.dialog_loop.exit(0)  # Stop the event loop
         super().reject()
@@ -143,8 +227,13 @@ class ThreadedCapturePrintDialogBitBox02(QDialog):
     def get_result(self) -> bool:
         self.show()  # Show the dialog
 
-        self._thread.start()  # Start the thread
+        self._thread = threading.Thread(target=self._run_func, daemon=True, name="BitBox02DialogWorker")
+        self._thread.start()
         self.loop.exec()  # Block here until the operation finishes
+
+        if self._worker_error is not None:
+            self.end_thread()
+            raise self._worker_error
 
         # if no button was clicked yet, then block until one is clicked
         if self.button_click_result is None:
@@ -155,10 +244,9 @@ class ThreadedCapturePrintDialogBitBox02(QDialog):
         self.end_thread()
         return total_result
 
-    def end_thread(self):
-        if self._thread.isRunning():
-            self._thread.quit()
-            self._thread.wait()
+    def end_thread(self) -> None:
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1.0)
 
 
 def bdknetwork_to_chain(network: bdk.Network):
@@ -205,19 +293,32 @@ class DialogNoiseConfig(CLINoiseConfig):
     """Noise pairing and attestation check handling in the terminal (stdin/stdout)"""
 
     def show_pairing(self, code: str, device_response: Callable[[], bool]) -> bool:
-        self.threaded_dialog = ThreadedCapturePrintDialogBitBox02(
-            func=device_response,
-            title=translate("usb", "Pair Bitbox02"),
-        )
-        self.threaded_dialog.add_text(
-            translate(
-                "usb",
-                "Please compare and confirm the pairing code on your BitBox02:\n\n{code}",
-            ).format(code=code)
-        )
-        result = self.threaded_dialog.get_result()
+        app = QCoreApplication.instance()
+        if app is None or QThread.currentThread() is app.thread():
+            self.threaded_dialog = ThreadedCapturePrintDialogBitBox02(
+                func=device_response,
+                title=translate("usb", "Pair Bitbox02"),
+            )
+            self.threaded_dialog.add_text(
+                translate(
+                    "usb",
+                    "Please compare and confirm the pairing code on your BitBox02:\n\n{code}",
+                ).format(code=code)
+            )
+            return self.threaded_dialog.get_result()
 
-        return result
+        pairing_request = _PairingRequest(code=code, device_response=device_response)
+        QMetaObject.invokeMethod(
+            _get_main_thread_bitbox02_pairing_prompt(),
+            "show_pairing_dialog",
+            Qt.ConnectionType.QueuedConnection,
+            Q_ARG(object, pairing_request),
+        )
+        pairing_request.done.wait()
+
+        if pairing_request.error is not None:
+            raise pairing_request.error
+        return bool(pairing_request.result)
 
     def attestation_check(self, result: bool) -> None:
         if result:

--- a/bitcoin_usb/dialogs.py
+++ b/bitcoin_usb/dialogs.py
@@ -1,11 +1,14 @@
+import asyncio
 import sys
 from collections.abc import Callable
+from concurrent.futures import Future
 from enum import Enum
 from functools import partial
 from typing import Any
 
 import bdkpython as bdk
-from PyQt6.QtCore import QObject, Qt, QThread, pyqtSignal
+from bitcoin_safe_lib.async_tools.loop_in_thread import LoopInThread
+from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QCloseEvent, QGuiApplication, QIcon, QShowEvent
 from PyQt6.QtWidgets import (
     QDialog,
@@ -48,27 +51,7 @@ def get_message_box(
     return msg_box
 
 
-# Worker class for the blocking operation
-class Worker(QObject):
-    finished = pyqtSignal(object)
-    error = pyqtSignal(Exception)  # New signal for errors
-
-    def __init__(self, func, *args, **kwargs):
-        super().__init__()
-        self.func = func
-        self.args = args
-        self.kwargs = kwargs
-
-    def run(self):
-        try:
-            func_result = self.func(*self.args, **self.kwargs)
-            self.finished.emit(func_result)  # Emit the func_result if successful
-        except Exception as e:
-            self.error.emit(e)  # Emit error if an exception occurs
-
-
 class DeviceDialog(QDialog):
-    _detached_scan_threads: set[QThread] = set()
     _usb_icon_path = get_icon_path("bi--usb-symbol.svg")
     _bluetooth_icon_path = get_icon_path("bi--bluetooth.svg")
 
@@ -76,6 +59,7 @@ class DeviceDialog(QDialog):
         self,
         parent,
         network: bdk.Network,
+        loop_in_thread: LoopInThread,
         usb_scan_callback: Callable[[], list[dict[str, Any]]],
         bluetooth_scan_callback: Callable[[], list[dict[str, Any]]] | None = None,
         install_udev_callback: Callable[[], None] | None = None,
@@ -91,6 +75,7 @@ class DeviceDialog(QDialog):
         self.setModal(True)
 
         self.network = network
+        self.loop_in_thread = loop_in_thread
         self.usb_scan_callback = usb_scan_callback
         self.bluetooth_scan_callback = bluetooth_scan_callback
         self.install_udev_callback = install_udev_callback
@@ -98,8 +83,8 @@ class DeviceDialog(QDialog):
         self.autoscan_mode = autoscan_mode
         self.selected_device: dict[str, Any] | None = None
         self._devices_by_key: dict[tuple[str, str, str], dict[str, Any]] = {}
-        self._scan_thread: QThread | None = None
-        self._scan_worker: Worker | None = None
+        self._active_scan_future: Future[list[dict[str, Any]]] | None = None
+        self._active_scan_token = 0
         self._has_auto_scanned_on_open = False
         self._has_completed_usb_scan = False
         self._scan_finished_message = ""
@@ -341,7 +326,9 @@ class DeviceDialog(QDialog):
 
         return self.tr("Try to {actions}.").format(actions=action_text)
 
-    def _on_scan_result(self, source: str, result: object):
+    def _on_scan_result(self, source: str, token: int, result: object) -> None:
+        if token != self._active_scan_token:
+            return
         devices = result if isinstance(result, list) else []
         transport = "bluetooth" if source == "bluetooth" else "usb"
         self._replace_devices_for_transport(transport=transport, devices=devices)
@@ -360,7 +347,9 @@ class DeviceDialog(QDialog):
 
         self._on_scan_finished()
 
-    def _on_scan_error(self, source: str, exception: Exception):
+    def _on_scan_error(self, source: str, token: int, exception: BaseException) -> None:
+        if token != self._active_scan_token:
+            return
         if source == "usb":
             self._has_completed_usb_scan = True
             self._update_install_udev_button_visibility()
@@ -372,7 +361,7 @@ class DeviceDialog(QDialog):
         ).exec()
         self._on_scan_finished()
 
-    def _on_scan_finished(self):
+    def _on_scan_finished(self) -> None:
         self._set_scanning(False)
         self._set_instructions_message(self._scan_finished_message)
         self._scan_finished_message = ""
@@ -383,72 +372,30 @@ class DeviceDialog(QDialog):
                 self._set_default_action_button(device_button)
         else:
             self._set_default_action_button(self._default_scan_button())
-        self._stop_scan(wait_timeout_ms=50)
+        self._active_scan_future = None
 
-    @classmethod
-    def _track_detached_scan_thread(cls, thread: QThread, worker: Worker | None) -> None:
-        cls._detached_scan_threads.add(thread)
-
-        def _cleanup_detached_thread() -> None:
-            if worker:
-                worker.deleteLater()
-            thread.deleteLater()
-            cls._detached_scan_threads.discard(thread)
-
-        thread.finished.connect(_cleanup_detached_thread)
-
-    @staticmethod
-    def _disconnect_scan_worker(worker: Worker) -> None:
-        for signal in (worker.finished, worker.error):
-            try:
-                signal.disconnect()
-            except TypeError:
-                # No connections remain.
-                pass
-
-    def _stop_scan(self, wait_timeout_ms: int) -> None:
-        worker = self._scan_worker
-        thread = self._scan_thread
-        self._scan_worker = None
-        self._scan_thread = None
-
-        if not thread:
-            return
-
-        if worker:
-            self._disconnect_scan_worker(worker)
-
-        if thread.isRunning():
-            thread.requestInterruption()
-            thread.quit()
-            if wait_timeout_ms > 0 and thread.wait(wait_timeout_ms):
-                if worker:
-                    worker.deleteLater()
-                thread.deleteLater()
-                return
-            thread.setParent(None)
-            self._track_detached_scan_thread(thread=thread, worker=worker)
-            return
-
-        if worker:
-            worker.deleteLater()
-        thread.deleteLater()
+    def _stop_scan(self) -> None:
+        future = self._active_scan_future
+        self._active_scan_future = None
+        self._active_scan_token += 1
+        if future is not None:
+            future.cancel()
 
     def _start_scan(
         self, scan_fn: Callable[[], list[dict[str, Any]]], source: str, message: str, finished_message: str
     ) -> None:
-        if self._scan_thread and self._scan_thread.isRunning():
+        if self._active_scan_future and not self._active_scan_future.done():
             return
 
         self._set_scanning(True)
         self._scan_finished_message = finished_message
-        self._scan_worker = Worker(scan_fn)
-        self._scan_thread = QThread(self)
-        self._scan_worker.moveToThread(self._scan_thread)
-        self._scan_thread.started.connect(self._scan_worker.run)
-        self._scan_worker.finished.connect(lambda result: self._on_scan_result(source, result))
-        self._scan_worker.error.connect(lambda exception: self._on_scan_error(source, exception))
-        self._scan_thread.start()
+        self._active_scan_token += 1
+        token = self._active_scan_token
+        self._active_scan_future = self.loop_in_thread.run_task(
+            asyncio.to_thread(scan_fn),
+            on_success=lambda result: self._on_scan_result(source, token, result),
+            on_error=lambda exc_info: self._on_scan_error(source, token, exc_info[1]),
+        )
         self._set_instructions_message(message)
 
     def scan_usb_devices(self):
@@ -480,7 +427,7 @@ class DeviceDialog(QDialog):
             self.scan_for_bluetooth_devices()
 
     def closeEvent(self, a0: QCloseEvent | None) -> None:
-        self._stop_scan(wait_timeout_ms=0)
+        self._stop_scan()
         super().closeEvent(a0)
 
     def showEvent(self, a0: QShowEvent | None) -> None:

--- a/bitcoin_usb/trezor_thp.py
+++ b/bitcoin_usb/trezor_thp.py
@@ -19,7 +19,8 @@ from hwilib.errors import (
 from hwilib.hwwclient import HardwareWalletClient
 from hwilib.key import ExtendedKey
 from hwilib.psbt import PSBT
-from PyQt6.QtCore import QCoreApplication, QObject, QThread, pyqtSignal
+from PyQt6 import sip
+from PyQt6.QtCore import Q_ARG, QCoreApplication, QMetaObject, QObject, Qt, QThread, pyqtSlot
 from PyQt6.QtWidgets import QInputDialog, QLineEdit
 from trezorlib import device, messages
 from trezorlib.client import AppManifest, PassphraseSetting, TrezorClient
@@ -28,7 +29,8 @@ from trezorlib.models import T3W1, TrezorModel
 from trezorlib.thp.client import TrezorClientThp
 from trezorlib.thp.credentials import Credential
 from trezorlib.thp.pairing import default_pairing_flow
-from trezorlib.transport import enumerate_devices as trezorlib_enumerate_devices
+from trezorlib.transport import Transport
+from trezorlib.transport import all_transports as trezorlib_all_transports
 from trezorlib.transport import get_transport as trezorlib_get_transport
 
 from bitcoin_usb.i18n import translate
@@ -52,16 +54,8 @@ class _TextRequest:
 
 
 class _MainThreadTextPrompt(QObject):
-    request_text = pyqtSignal(object)
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.request_text.connect(self._show_text_dialog)
-
-    def request(self, text_request: _TextRequest) -> None:
-        self.request_text.emit(text_request)
-
-    def _show_text_dialog(self, payload: object) -> None:
+    @pyqtSlot(object)
+    def show_text_dialog(self, payload: object) -> None:
         if not isinstance(payload, _TextRequest):
             raise TypeError(f"Unexpected payload type: {type(payload)!r}")
 
@@ -73,7 +67,17 @@ class _MainThreadTextPrompt(QObject):
             payload.done.set()
 
 
-_MAIN_THREAD_TEXT_PROMPT = _MainThreadTextPrompt()
+_MAIN_THREAD_TEXT_PROMPT: _MainThreadTextPrompt | None = None
+
+
+def _get_main_thread_text_prompt() -> _MainThreadTextPrompt:
+    global _MAIN_THREAD_TEXT_PROMPT
+    if _MAIN_THREAD_TEXT_PROMPT is None or sip.isdeleted(_MAIN_THREAD_TEXT_PROMPT):
+        _MAIN_THREAD_TEXT_PROMPT = _MainThreadTextPrompt()
+        app = QCoreApplication.instance()
+        if app is not None:
+            _MAIN_THREAD_TEXT_PROMPT.moveToThread(app.thread())
+    return _MAIN_THREAD_TEXT_PROMPT
 
 
 def is_trezor_modern_device(device_info: dict[str, Any]) -> bool:
@@ -93,11 +97,25 @@ def _should_use_local_trezor_client(client: TrezorClient) -> bool:
     )
 
 
+def _enumerate_trezor_transports() -> list[Transport]:
+    devices: list[Transport] = []
+    for transport_cls in trezorlib_all_transports():
+        if transport_cls.PATH_PREFIX == "ble":
+            continue
+        try:
+            devices.extend(list(transport_cls.enumerate()))
+        except Exception as exc:
+            logger.debug(
+                "Skipping failed Trezor transport enumeration for %s: %s", transport_cls.__name__, exc
+            )
+    return devices
+
+
 def enumerate_trezor_thp_devices() -> list[dict[str, Any]]:
     app = AppManifest(app_name=TREZOR_APP_NAME)
     devices: list[dict[str, Any]] = []
 
-    for transport in trezorlib_enumerate_devices():
+    for transport in _enumerate_trezor_transports():
         path = transport.get_path()
         if path.startswith("ble:"):
             transport.close()
@@ -143,7 +161,12 @@ def _request_text(title: str, label: str, echo: QLineEdit.EchoMode = QLineEdit.E
         return _show_text_dialog(title, label, echo)
 
     text_request = _TextRequest(title=title, label=label, echo=echo)
-    _MAIN_THREAD_TEXT_PROMPT.request(text_request)
+    QMetaObject.invokeMethod(
+        _get_main_thread_text_prompt(),
+        "show_text_dialog",
+        Qt.ConnectionType.QueuedConnection,
+        Q_ARG(object, text_request),
+    )
     text_request.done.wait()
 
     if text_request.error is not None:

--- a/bitcoin_usb/usb_gui.py
+++ b/bitcoin_usb/usb_gui.py
@@ -148,6 +148,7 @@ class USBGui(QObject):
         dialog = DeviceDialog(
             self._parent,
             network=self.network,
+            loop_in_thread=self.loop_in_thread,
             usb_scan_callback=self.get_devices,
             bluetooth_scan_callback=bluetooth_scan_callback,
             install_udev_callback=self.linux_cmd_install_udev_as_sudo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ disable_error_code = "assignment"
 
 [tool.poetry]
 name = "bitcoin-usb"
-version = "4.3.1"
+version = "4.3.2"
 authors = ["andreasgriffin <andreasgriffin@proton.me>"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/tests/test_bluetooth_scan_support.py
+++ b/tests/test_bluetooth_scan_support.py
@@ -75,6 +75,7 @@ def test_get_device_exposes_bluetooth_scan_callback_when_enabled(monkeypatch) ->
             self,
             parent,
             network,
+            loop_in_thread,
             usb_scan_callback,
             bluetooth_scan_callback,
             install_udev_callback,
@@ -84,6 +85,7 @@ def test_get_device_exposes_bluetooth_scan_callback_when_enabled(monkeypatch) ->
         ):
             _ = parent
             _ = network
+            _ = loop_in_thread
             _ = usb_scan_callback
             _ = install_udev_callback
             _ = autoselect_if_1_device
@@ -118,6 +120,7 @@ def test_get_device_hides_bluetooth_scan_callback_when_disabled(monkeypatch) -> 
             self,
             parent,
             network,
+            loop_in_thread,
             usb_scan_callback,
             bluetooth_scan_callback,
             install_udev_callback,
@@ -127,6 +130,7 @@ def test_get_device_hides_bluetooth_scan_callback_when_disabled(monkeypatch) -> 
         ):
             _ = parent
             _ = network
+            _ = loop_in_thread
             _ = usb_scan_callback
             _ = install_udev_callback
             _ = autoselect_if_1_device
@@ -157,6 +161,7 @@ def test_get_device_passes_window_icon_to_dialog(monkeypatch) -> None:
             self,
             parent,
             network,
+            loop_in_thread,
             usb_scan_callback,
             bluetooth_scan_callback,
             install_udev_callback,
@@ -166,6 +171,7 @@ def test_get_device_passes_window_icon_to_dialog(monkeypatch) -> None:
         ):
             _ = parent
             _ = network
+            _ = loop_in_thread
             _ = usb_scan_callback
             _ = bluetooth_scan_callback
             _ = install_udev_callback

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -1,5 +1,11 @@
+import threading
+import time
+from concurrent.futures import Future
 from types import SimpleNamespace
 
+from PyQt6.QtCore import QCoreApplication
+
+from bitcoin_usb.device import DialogNoiseConfig, ThreadedCapturePrintDialogBitBox02
 from bitcoin_usb.dialogs import DeviceDialog
 
 
@@ -46,9 +52,9 @@ def test_on_scan_finished_defaults_to_first_device_button(monkeypatch) -> None:
         install_udev_button=_FakeButton(),
         cancel_button=_FakeButton(),
         _scan_finished_message="",
+        _active_scan_future=None,
         _set_scanning=lambda scanning: None,
         _set_instructions_message=lambda message: None,
-        _stop_scan=lambda wait_timeout_ms: None,
     )
     dialog._set_default_action_button = lambda button: DeviceDialog._set_default_action_button(dialog, button)  # type:  ignore
 
@@ -70,9 +76,10 @@ def test_on_scan_finished_defaults_to_usb_scan_button_when_empty(monkeypatch) ->
         install_udev_button=_FakeButton(),
         cancel_button=_FakeButton(),
         _scan_finished_message="",
+        _active_scan_future=None,
         _set_scanning=lambda scanning: None,
         _set_instructions_message=lambda message: None,
-        _stop_scan=lambda wait_timeout_ms: None,
+        _default_scan_button=lambda: usb_scan_button,
     )
     dialog._set_default_action_button = lambda button: DeviceDialog._set_default_action_button(dialog, button)  # type:  ignore
 
@@ -93,6 +100,7 @@ def test_on_scan_result_refreshes_dialog_size() -> None:
             devices_by_key[(device["type"], device["path"], device["transport"])] = device
 
     dialog = SimpleNamespace(
+        _active_scan_token=1,
         _devices_by_key=devices_by_key,
         _has_completed_usb_scan=False,
         _replace_devices_for_transport=replace_devices,
@@ -106,7 +114,197 @@ def test_on_scan_result_refreshes_dialog_size() -> None:
     DeviceDialog._on_scan_result(
         dialog,  # type:  ignore
         "bluetooth",
+        1,
         [{"type": "trezor", "path": "ble:1", "transport": "bluetooth"}],
     )
 
     assert calls == ["replace:bluetooth:1", "render", "resize", "finished"]
+
+
+def test_start_scan_uses_loop_in_thread_callbacks() -> None:
+    calls: list[str] = []
+
+    class _FakeLoop:
+        def run_task(self, coro, on_success=None, on_error=None):
+            coro.close()
+            calls.append("run_task")
+            if on_success is not None:
+                on_success([{"type": "trezor", "path": "usb:1"}])
+            future: Future[list[dict[str, str]]] = Future()
+            future.set_result([{"type": "trezor", "path": "usb:1"}])
+            return future
+
+    dialog = SimpleNamespace(
+        loop_in_thread=_FakeLoop(),
+        _active_scan_future=None,
+        _active_scan_token=0,
+        _set_scanning=lambda scanning: calls.append(f"scanning:{scanning}"),
+        _set_instructions_message=lambda message: calls.append(f"message:{message}"),
+        _scan_finished_message="",
+        _on_scan_result=lambda source, token, result: calls.append(f"result:{source}:{token}:{len(result)}"),
+        _on_scan_error=lambda source, token, exception: calls.append(f"error:{source}:{token}:{exception}"),
+    )
+
+    DeviceDialog._start_scan(
+        dialog,  # type: ignore[arg-type]
+        scan_fn=lambda: [{"type": "trezor", "path": "usb:1"}],
+        source="usb",
+        message="scan",
+        finished_message="done",
+    )
+
+    assert calls == ["scanning:True", "run_task", "result:usb:1:1", "message:scan"]
+    assert dialog._scan_finished_message == "done"
+
+
+def test_stop_scan_cancels_active_future_and_invalidates_token() -> None:
+    future: Future[object] = Future()
+    dialog = SimpleNamespace(
+        _active_scan_future=future,
+        _active_scan_token=5,
+    )
+
+    DeviceDialog._stop_scan(dialog)  # type: ignore[arg-type]
+
+    assert future.cancelled() is True
+    assert dialog._active_scan_future is None
+    assert dialog._active_scan_token == 6
+
+
+def test_scan_callbacks_ignore_stale_tokens() -> None:
+    calls: list[str] = []
+    dialog = SimpleNamespace(
+        _active_scan_token=2,
+        _devices_by_key={},
+        _has_completed_usb_scan=False,
+        _replace_devices_for_transport=lambda transport, devices: calls.append(
+            f"replace:{transport}:{len(devices)}"
+        ),
+        _update_install_udev_button_visibility=lambda: calls.append("udev"),
+        _render_devices=lambda: calls.append("render"),
+        _refresh_dialog_size=lambda: calls.append("resize"),
+        _on_scan_finished=lambda: calls.append("finished"),
+        autoselect_if_1_device=False,
+    )
+
+    DeviceDialog._on_scan_result(dialog, "usb", 1, [{"type": "trezor", "path": "usb:1"}])  # type: ignore[arg-type]
+    DeviceDialog._on_scan_error(dialog, "usb", 1, RuntimeError("boom"))  # type: ignore[arg-type]
+
+    assert calls == []
+
+
+def test_threaded_capture_print_dialog_run_func_emits_result() -> None:
+    captured: list[object] = []
+
+    class _Signal:
+        def emit(self, value: object) -> None:
+            captured.append(value)
+
+    dialog = SimpleNamespace(
+        _func=lambda: True,
+        _args=(),
+        _kwargs={},
+        _bridge=SimpleNamespace(finished=_Signal(), error=_Signal()),
+    )
+
+    ThreadedCapturePrintDialogBitBox02._run_func(dialog)  # type: ignore[arg-type]
+
+    assert captured == [True]
+
+
+def test_threaded_capture_print_dialog_run_func_emits_error() -> None:
+    captured: list[object] = []
+
+    class _Signal:
+        def emit(self, value: object) -> None:
+            captured.append(value)
+
+    dialog = SimpleNamespace(
+        _func=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        _args=(),
+        _kwargs={},
+        _bridge=SimpleNamespace(finished=_Signal(), error=_Signal()),
+    )
+
+    ThreadedCapturePrintDialogBitBox02._run_func(dialog)  # type: ignore[arg-type]
+
+    assert len(captured) == 1
+    assert isinstance(captured[0], RuntimeError)
+    assert str(captured[0]) == "boom"
+
+
+def test_threaded_capture_print_dialog_handle_error_closes_dialog() -> None:
+    calls: list[str] = []
+
+    class _Loop:
+        def __init__(self, running: bool) -> None:
+            self._running = running
+
+        def isRunning(self) -> bool:
+            return self._running
+
+        def exit(self, code: int | None = None) -> None:
+            calls.append(f"exit:{code}")
+
+    dialog = SimpleNamespace(
+        _worker_error=None,
+        loop=_Loop(True),
+        dialog_loop=_Loop(True),
+        close=lambda: calls.append("close"),
+    )
+
+    ThreadedCapturePrintDialogBitBox02.handle_func_error(dialog, RuntimeError("boom"))  # type: ignore[arg-type]
+
+    assert isinstance(dialog._worker_error, RuntimeError)
+    assert calls == ["exit:None", "exit:0", "close"]
+
+
+def test_bitbox02_pairing_requests_use_main_thread(monkeypatch) -> None:
+    app = QCoreApplication.instance()
+    if app is None:
+        app = QCoreApplication([])
+
+    main_thread_ident = threading.get_ident()
+    captured: dict[str, object] = {}
+    result: dict[str, bool] = {}
+    errors: list[Exception] = []
+
+    class _FakeDialog:
+        def __init__(self, func, title="Processing...", message="", *args, **kwargs) -> None:
+            _ = args
+            _ = kwargs
+            _ = message
+            captured["thread_ident"] = threading.get_ident()
+            captured["title"] = title
+            self._func = func
+
+        def add_text(self, text: str) -> None:
+            captured["text"] = text
+
+        def get_result(self) -> bool:
+            return self._func()
+
+    monkeypatch.setattr("bitcoin_usb.device.ThreadedCapturePrintDialogBitBox02", _FakeDialog)
+
+    def run_request() -> None:
+        try:
+            result["value"] = DialogNoiseConfig().show_pairing("123456", lambda: True)
+        except Exception as exc:  # pragma: no cover - assertion below reports failures
+            errors.append(exc)
+
+    worker = threading.Thread(target=run_request)
+    worker.start()
+
+    deadline = time.monotonic() + 2.0
+    while worker.is_alive() and time.monotonic() < deadline:
+        QCoreApplication.processEvents()
+        time.sleep(0.01)
+
+    worker.join(timeout=1.0)
+
+    assert not worker.is_alive()
+    assert not errors
+    assert result["value"] is True
+    assert captured["thread_ident"] == main_thread_ident
+    assert captured["title"] == "Pair Bitbox02"
+    assert "123456" in str(captured["text"])

--- a/tests/test_trezor_thp_support.py
+++ b/tests/test_trezor_thp_support.py
@@ -15,6 +15,7 @@ from bitcoin_usb.trezor_thp import (
     TrezorThpClient,
     _HwiMessageBridge,
     _HwiTrezorSessionAdapter,
+    _enumerate_trezor_transports,
     _request_text,
 )
 from bitcoin_usb.usb_gui import USBGui, enumerate_available_devices
@@ -52,6 +53,48 @@ def test_enumerate_available_devices_merges_trezor_thp(monkeypatch) -> None:
     assert {"type": "jade", "path": "usb:1"} in devices
     assert {"type": "trezor", "path": "webusb:001", "model": "Safe 7", "protocol": "thp"} in devices
     assert len(devices) == 2
+
+
+def test_enumerate_trezor_transports_skips_ble(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class FakeTransport:
+        def __init__(self, path: str) -> None:
+            self._path = path
+
+        def get_path(self) -> str:
+            return self._path
+
+        def close(self) -> None:
+            return None
+
+    class FakeBleTransport:
+        PATH_PREFIX = "ble"
+        __name__ = "FakeBleTransport"
+
+        @classmethod
+        def enumerate(cls) -> list[FakeTransport]:
+            calls.append(cls.PATH_PREFIX)
+            raise AssertionError("BLE transport should not be enumerated")
+
+    class FakeWebUsbTransport:
+        PATH_PREFIX = "webusb"
+        __name__ = "FakeWebUsbTransport"
+
+        @classmethod
+        def enumerate(cls) -> list[FakeTransport]:
+            calls.append(cls.PATH_PREFIX)
+            return [FakeTransport("webusb:001")]
+
+    monkeypatch.setattr(
+        "bitcoin_usb.trezor_thp.trezorlib_all_transports",
+        lambda: [FakeBleTransport, FakeWebUsbTransport],
+    )
+
+    transports = _enumerate_trezor_transports()
+
+    assert calls == ["webusb"]
+    assert [transport.get_path() for transport in transports] == ["webusb:001"]
 
 
 def test_trezor_thp_devices_run_inline() -> None:

--- a/tests/test_usb_gui_jade_threading.py
+++ b/tests/test_usb_gui_jade_threading.py
@@ -129,3 +129,11 @@ def test_get_fingerprint_and_xpubs_runs_inline_for_usb_on_macos(monkeypatch) -> 
     result = gui.get_fingerprint_and_xpubs()
 
     assert result == (selected_device, "f00dbabe", {})
+
+
+def test_bitbox02_usb_devices_run_in_worker_on_linux(monkeypatch) -> None:
+    selected_device = {"type": "bitbox02", "path": "usb:1"}
+
+    monkeypatch.setattr(usb_gui.platform, "system", lambda: "Linux")
+
+    assert USBGui._should_run_in_worker(selected_device) is True


### PR DESCRIPTION
- Refactored device dialog threading from PyQt6 QThread to Python `threading.Thread` with async/await patterns via `LoopInThread`
- Replaced custom `Worker` class with direct thread spawning and signal emission
- Added cross-thread dialog marshalling for BitBox02 pairing using `QMetaObject.invokeMethod` to ensure UI operations run on main thread
- Implemented token-based cancellation mechanism for device scans to prevent stale callbacks
- Added defensive checks for deleted Qt objects using `sip.isdeleted()`
- Updated Trezor transport enumeration to skip Bluetooth (BLE) transports
- Version bump to 4.3.2
- Comprehensive test coverage for new threading patterns and cross-thread marshalling